### PR TITLE
Fix test output parsing when test timing omitted.

### DIFF
--- a/src/test-executable.ts
+++ b/src/test-executable.ts
@@ -24,9 +24,9 @@ export class TestExecutable {
     testItem: vscode.TestItem;
 
     private readonly regexEnterTestSuite = /^(.+): Entering test suite "(\w+)"$/;
-    private readonly regexLeaveTestSuite = /^(.+): Leaving test suite "(\w+)"; testing time: (\d+)(\w+)$/;
+    private readonly regexLeaveTestSuite = /^(.+): Leaving test suite "(\w+)"(?:; testing time: (\d+)(\w+))?$/;
     private readonly regexEnterTestCase = /^(.+): Entering test case "(\w+)"$/;
-    private readonly regexLeaveTestCase = /^(.+): Leaving test case "(\w+)"; testing time: (\d+)(\w+)$/;
+    private readonly regexLeaveTestCase = /^(.+): Leaving test case "(\w+)"(?:; testing time: (\d+)(\w+))?$/;
     private readonly regexTestCaseError = /^(.+)\(([0-9]+)\): error: in "([\w\/]+)": (.+)$/;
     private readonly regexTestCaseFatalError = /^(.+)\(([0-9]+)\): fatal error: in "([\w\/]+)": (.+)$/;
 


### PR DESCRIPTION
The test output parser expects to see lines like: `leaving test [suite|case] <name>; testing time: <x>ms`.

However, it is possible for the "testing time" part of the test output to be omitted. This happens if the test duration is less than the resolution of the timer which boost uses, see: https://github.com/boostorg/test/blob/ee721298d41dc429878e2d5df15eaa69a58eff14/include/boost/test/impl/compiler_log_formatter.ipp#L116C24-L116C24

This change allows such tests to be parsed successfully.