### PR TITLE
Fixed bugs and added workspace folder filter feature

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,11 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
+      "sourceMaps": true,
       "outFiles": [
-        "${workspaceFolder}/lib"
-      ]
+        "${workspaceFolder}/lib/**/*.js"
+      ],
+      "preLaunchTask": "npm:watch"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "npm:build",
+			"type": "shell",
+			"command": "npm run build"
+		},
+		{
+			"label": "npm:watch",
+			"type": "shell",
+			"command": "npm run watch",
+			"isBackground": true
+		}
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,138 +1,200 @@
 {
   "name": "boost-test-adapter-feher",
-  "version": "3.2.0-pre2",
-  "lockfileVersion": 1,
+  "version": "3.2.5",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/node": {
+  "packages": {
+    "": {
+      "name": "boost-test-adapter-feher",
+      "version": "3.2.5",
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.1.4",
+        "dotparser": "^1.1.1",
+        "tslib": "^1.14.1"
+      },
+      "devDependencies": {
+        "@types/node": "8.9.3",
+        "@types/vscode": "1.67.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^3.9.10"
+      },
+      "engines": {
+        "vscode": "^1.67.0"
+      }
+    },
+    "node_modules/@types/node": {
       "version": "8.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
       "integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "@types/vscode": {
+    "node_modules/@types/vscode": {
       "version": "1.67.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
       "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "async-mutex": {
+    "node_modules/async-mutex": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.1.4.tgz",
-      "integrity": "sha512-zVWTmAnxxHaeB2B1te84oecI8zTDJ/8G49aVBblRX6be0oq6pAybNcUSxwfgVOmOjSCvN4aYZAqwtyNI8e1YGw=="
+      "integrity": "sha512-zVWTmAnxxHaeB2B1te84oecI8zTDJ/8G49aVBblRX6be0oq6pAybNcUSxwfgVOmOjSCvN4aYZAqwtyNI8e1YGw==",
+      "license": "MIT"
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "dotparser": {
+    "node_modules/dotparser": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/dotparser/-/dotparser-1.1.1.tgz",
-      "integrity": "sha512-8ojhUts0HbLnXJgjTiJOddwVVBUk6hg4SJ5kGiuhzgK/f+y79TiWvICwx1oCWlVbBC8YI3nEaIQg9fjGYbGBXw=="
+      "integrity": "sha512-8ojhUts0HbLnXJgjTiJOddwVVBUk6hg4SJ5kGiuhzgK/f+y79TiWvICwx1oCWlVbBC8YI3nEaIQg9fjGYbGBXw==",
+      "license": "MIT"
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "rimraf": {
+    "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "tslib": {
+    "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "3.9.10",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "displayName": "Boost.Test Adapter",
   "description": "Run or debug your Boost.Test tests in the Sidebar of Visual Studio Code",
   "author": "Gabor Fekete <dev.feheren.fekete@gmail.com>",
+  "contributors": [
+    "Stefano Della Morte <stefano1996linc@gmail.com>"
+  ],
   "publisher": "feheren-fekete",
   "license": "MIT",
   "homepage": "https://github.com/feher/vscode-boost-test-adapter",

--- a/package.json
+++ b/package.json
@@ -54,68 +54,82 @@
     "configuration": {
       "title": "Boost.Test Adapter",
       "properties": {
-        "boost-test-adapter-feher.tests": {
-          "description": "Test configurations.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "description": "Test configuration.",
-            "properties": {
-              "testExecutables": {
-                "description": "List of test executables.",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "description": "A test executable.",
-                  "properties": {
-                    "path": {
-                      "description": "Absolute or relative path to a test executable.",
-                      "type": "string"
-                    },
-                    "label": {
-                      "description": "Show this label in the test explorer UI instead of the Boost Test module name.",
-                      "type": "string"
+        "boost-test-adapter-feher": {
+          "description": "Configuration for Boost.Test Adapter extension",
+          "type": "object",
+          "properties": {
+            "disabledWorkspaceFolders": {
+              "description": "Disabled workspace folders names in multiroot environment",
+              "type": "array",
+              "items": "string",
+              "default": [],
+              "scope": "window"
+            },
+            "tests": {
+              "description": "Test configurations.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "description": "Test configuration.",
+                "properties": {
+                  "testExecutables": {
+                    "description": "List of test executables.",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "description": "A test executable.",
+                      "properties": {
+                        "path": {
+                          "description": "Absolute or relative path to a test executable.",
+                          "type": "string"
+                        },
+                        "label": {
+                          "description": "Show this label in the test explorer UI instead of the Boost Test module name.",
+                          "type": "string"
+                        }
+                      }
                     }
+                  },
+                  "debugConfig": {
+                    "description": "The name of a launch configuration used for debugging.",
+                    "type": "string"
+                  },
+                  "envFile": {
+                    "description": "A simple key=value file with environment variables for running and debugging the tests.",
+                    "type": "string"
+                  },
+                  "env": {
+                    "description": "Environment variables for running and debugging the tests.",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "description": "Environment variable.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value of the environment variable.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "cwd": {
+                    "description": "Working directory for the test executable.",
+                    "type": "string"
+                  },
+                  "sourcePrefix": {
+                    "description": "Used to convert relative source file paths to absolute paths. It's needed only if the test-case file paths are broken in the Test Explorer UI.",
+                    "type": "string"
                   }
                 }
               },
-              "debugConfig": {
-                "description": "The name of a launch configuration used for debugging.",
-                "type": "string"
-              },
-              "envFile": {
-                "description": "A simple key=value file with environment variables for running and debugging the tests.",
-                "type": "string"
-              },
-              "env": {
-                "description": "Environment variables for running and debugging the tests.",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "description": "Environment variable.",
-                  "properties": {
-                    "name": {
-                      "description": "Name of the environment variable.",
-                      "type": "string"
-                    },
-                    "value": {
-                      "description": "Value of the environment variable.",
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "cwd": {
-                "description": "Working directory for the test executable.",
-                "type": "string"
-              },
-              "sourcePrefix": {
-                "description": "Used to convert relative source file paths to absolute paths. It's needed only if the test-case file paths are broken in the Test Explorer UI.",
-                "type": "string"
-              }
+              "default": [ ],
+              "scope": "resource"
             }
           },
-          "default": [],
           "scope": "resource"
         }
       }

--- a/src/adapter-manager.ts
+++ b/src/adapter-manager.ts
@@ -65,8 +65,9 @@ export class AdapterManager {
         this.log.info("Reloading tests");
         this.ctrl.items.replace([]);
         for (const [_, adapter] of this.adapters) {
-            await adapter.reload();
-            this.ctrl.items.add(adapter.getTestItem());
+            if (await adapter.reload()) {
+                this.ctrl.items.add(adapter.getTestItem());
+            }
         }
     }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -40,25 +40,35 @@ export class BoostTestAdapter {
         });
     }
 
-    async reload(): Promise<void> {
-        await this.updateSettings();
-        await this.load();
+    async reload(): Promise<boolean> {
+        const enabled = await this.updateSettings();
+        if ( enabled ) {
+            await this.load();
+            return true;
+        }
+        return false;
     }
 
-    private async updateSettings(): Promise<void> {
+    private async updateSettings(): Promise<boolean> {
         const release = await this.mutex.acquire();
+        let enabled = false;
         try {
-            await this.updateSettingsUnlocked();
+            enabled = await this.updateSettingsUnlocked();
         } finally {
             release();
+            return enabled;
         }
     }
 
-    private async updateSettingsUnlocked(): Promise<void> {
+    private async updateSettingsUnlocked(): Promise<boolean> {
         this.clearTestExeWatchers();
         this.testExecutables.clear();
 
         const cfg = await config.getConfig(this.workspaceFolder, this.log);
+
+        if (!cfg.enabled) {
+            return false;
+        }
 
         for (const cfgTestExe of cfg.testExes) {
             const testExeTestItemId = this.createTestExeId(cfgTestExe.path);
@@ -69,6 +79,8 @@ export class BoostTestAdapter {
                 cfgTestExe,
                 this.log));
         }
+
+        return true;
     }
 
     getTestItem(): vscode.TestItem {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,7 @@ export interface TestConfig {
 }
 
 export async function getConfig(workspaceFolder: vscode.WorkspaceFolder, log: logger.MyLogger): Promise<TestConfig> {
-    const cfg = vscode.workspace.getConfiguration(BoosTestAdapterConfig);
+    const cfg = vscode.workspace.getConfiguration(BoosTestAdapterConfig, workspaceFolder.uri);
 
     const disabledWorkspaceFolders = cfg.get<string[]>('disabledWorkspaceFolders');
     if ( Array.isArray( disabledWorkspaceFolders ) && disabledWorkspaceFolders.includes( workspaceFolder.name ) )

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,7 +53,7 @@ export async function getConfig(workspaceFolder: vscode.WorkspaceFolder, log: lo
                 return emptyTestConfig;
             }
             const testExe: TestExe = {
-                path: util.detokenizeVariables(cfgTestExe.path)
+                path: util.detokenizeVariables(cfgTestExe.path, workspaceFolder)
             };
 
             if (cfgTestExe.label !== undefined) {
@@ -76,7 +76,7 @@ export async function getConfig(workspaceFolder: vscode.WorkspaceFolder, log: lo
                     log.error(`Settings: cwd must be a string`);
                     return emptyTestConfig;
                 }
-                testExe.cwd = util.detokenizeVariables(cfgTest.cwd);
+                testExe.cwd = util.detokenizeVariables(cfgTest.cwd, workspaceFolder);
             }
 
             if (cfgTest.sourcePrefix !== undefined) {
@@ -92,7 +92,7 @@ export async function getConfig(workspaceFolder: vscode.WorkspaceFolder, log: lo
                     log.error(`Settings: envFile must be a string`, true);
                     return emptyTestConfig;
                 }
-                testExe.envFile = util.detokenizeVariables(cfgTest.envFile);
+                testExe.envFile = util.detokenizeVariables(cfgTest.envFile, workspaceFolder);
             }
 
             if (cfgTest.env !== undefined) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,19 +18,26 @@ export interface TestExe {
 }
 
 export interface TestConfig {
+    enabled: boolean;
     testExes: TestExe[];
 }
 
 export async function getConfig(workspaceFolder: vscode.WorkspaceFolder, log: logger.MyLogger): Promise<TestConfig> {
+    const cfg = vscode.workspace.getConfiguration(BoosTestAdapterConfig);
+
+    const disabledWorkspaceFolders = cfg.get<string[]>('disabledWorkspaceFolders');
+    if ( Array.isArray( disabledWorkspaceFolders ) && disabledWorkspaceFolders.includes( workspaceFolder.name ) )
+        return { enabled: false, testExes: [] };
+
     const emptyTestConfig: TestConfig = {
+        enabled: true,
         testExes: []
     };
     const testConfig: TestConfig = {
+        enabled: true,
         testExes: []
     };
-
-    const cfg = vscode.workspace.getConfiguration(BoosTestAdapterConfig);
-
+    
     const cfgTests = cfg.get<Record<string, any>[]>('tests');
     if (cfgTests === undefined) {
         log.warn(`Settings: No ${BoosTestAdapterConfig}.tests found.`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,25 +7,16 @@ export function stringHash(s: string): string {
 }
 
 // detokenizeVariables is based on https://github.com/DominicVonk/vscode-variables
-export function detokenizeVariables(rawValue: string, recursive = false): string {
-    let workspaces = vscode.workspace.workspaceFolders;
-    let workspace = vscode.workspace.workspaceFolders?.length ? vscode.workspace.workspaceFolders[0] : null;
+export function detokenizeVariables(rawValue: string, workspaceFolder: vscode.WorkspaceFolder, recursive = false): string {
     let activeFile = vscode.window.activeTextEditor?.document;
     let absoluteFilePath = activeFile?.uri.fsPath
-    rawValue = rawValue.replace(/\${workspaceFolder}/g, workspace?.uri.fsPath ?? "");
-    rawValue = rawValue.replace(/\${workspaceFolderBasename}/g, workspace?.name ?? "");
+    rawValue = rawValue.replace(/\${workspaceFolder}/g, workspaceFolder?.uri.fsPath ?? "");
+    rawValue = rawValue.replace(/\${workspaceFolderBasename}/g, workspaceFolder?.name ?? "");
     rawValue = rawValue.replace(/\${file}/g, absoluteFilePath ?? "");
-    let activeWorkspace = workspace;
     let relativeFilePath = absoluteFilePath;
-    for (let workspace of workspaces ?? []) {
-        if (absoluteFilePath?.replace(workspace.uri.fsPath, '') !== absoluteFilePath) {
-            activeWorkspace = workspace;
-            relativeFilePath = absoluteFilePath?.replace(workspace.uri.fsPath, '').substr(path.sep.length);
-            break;
-        }
-    }
+
     let parsedPath = path.parse(absoluteFilePath);
-    rawValue = rawValue.replace(/\${fileWorkspaceFolder}/g, activeWorkspace?.uri.fsPath ?? "");
+    rawValue = rawValue.replace(/\${fileWorkspaceFolder}/g, workspaceFolder?.uri.fsPath ?? "");
     rawValue = rawValue.replace(/\${relativeFile}/g, relativeFilePath ?? "");
     rawValue = rawValue.replace(/\${relativeFileDirname}/g, relativeFilePath?.substr(0, relativeFilePath.lastIndexOf(path.sep)) ?? "");
     rawValue = rawValue.replace(/\${fileBasename}/g, parsedPath.base ?? "");


### PR DESCRIPTION
Hello,

I fixed the following bugs:

- ${workspaceFolder} was always substituted with the first folder of the workspace (not good in multi-root environments)
- settings were scoped "resource" but resource settings were not considered (see get vscode.workspace.getConfiguration invocation)
Furthermore, I added the disabledWorkspaceFolders option (similar to the popular extension https://github.com/jest-community/vscode-jest)